### PR TITLE
Remove smaller padding for card layout

### DIFF
--- a/_sass/card.scss
+++ b/_sass/card.scss
@@ -11,7 +11,7 @@
 /* On mouse-over, add a deeper shadow */
 .card:hover {
 	box-shadow: 0 8px 16px 0 rgba(0,0,0,0.2);
-	border: solid #B4DDFC 1px;
+	border-color: #B4DDFC;
 }
 
 /* Add some padding inside the card container */


### PR DESCRIPTION
closes #23 

Hey @eileen-kuehn, this PR should solve the issue you found in #23, can you try it please? I added some padding initially to avoid cell breaks when hovering over the cards because the shadowed box around the card decreases the available area. But now I simply decreased the padding for the card-content, and this works fine I suppose.

Feel free to merge this PR when you are happy with the result.  