### PR TITLE
Adding first test for circle build, circle needs to be enabled

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,61 @@
+version: 2.1
+
+workflows:
+  version: 2
+
+  # The build workflow will build a preview for the site, intended for PRs
+  build:
+    jobs:
+      - build-site:
+          filters:
+            branches:
+              ignore: gh-pages
+
+
+build_jekyll: &build_jekyll
+    name: Jekyll Build
+    command: |
+        echo "Building RSE Blog for Preview"
+        cd ~/repo
+
+        # Update baseurl in config
+        BASEURL=https://${CIRCLE_BUILD_NUM}-267395254-gh.circle-artifacts.com/0/SORSE20
+        sed -i "17 s,.*,baseurl: $BASEURL,g" "_config.yml"
+        sed -i "18 s,.*,url: '',g" "_config.yml"
+
+        # Build site to download template
+        bundle exec jekyll build
+
+        grep -rlZ '\https' . | xargs -0 sed -i 's:/https:https:g'
+        grep -rlZ 'main.css' _site | xargs -0 sed -i "s,.*main.css.*,<link rel=\"stylesheet\" href=\"${BASEURL}/assets/css/main.css\">,g"
+
+ 
+
+jobs:
+  build-site:
+    docker:
+      - image: circleci/ruby:2.4.1
+    working_directory: ~/repo
+    environment:
+      - JEKYLL_ENV: production
+      - NOKOGIRI_USE_SYSTEM_LIBRARIES: true
+      - BUNDLE_PATH: ~/repo/vendor/bundle
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - v1-dependencies
+          - rubygems-v1
+      - run:
+          name: Bundle Install
+          command: |
+              cd ~/repo
+              bundle check || bundle install
+      - save_cache:
+          key: rubygems-v1
+          paths:
+            - vendor/bundle
+      - run: *build_jekyll
+      - store_artifacts:
+          path: ~/repo/_site
+          destination: SORSE20

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ New to Github? Don't worry, you'll figure it out fast and it's no problem if it 
   - `[Software demos]({{ site.data.committee.programme_teams.software_demo }})` :-1: :angry:
   - `[Software demos]({{ site.baseurl }}{{ site.data.committee.programme_teams.software_demo }})` :+1: :green_heart:
   
+
 ## Local installation
 As we cannot host one version of this site with github pages (generated from the master branch), you should build the website locally and test the implemented changes (or the reviewer in the pull request does it, this is fine as well). To build this site locally:
 
@@ -31,3 +32,12 @@ As we cannot host one version of this site with github pages (generated from the
 4. Run `bundle install`
 5. Serve the site locally via `bundle exec jekyll serve`
 6. Visit the site in the browser via http://localhost:4000
+
+## Preview the Site on CircleCI
+
+We use CircleCI to preview the site for pull requests, and this is controlled by the files
+in the [.circleci](.circleci) folder. To use CircleCI, you will need to
+ make sure you are logged in to the service and following the repository. When you select a build
+associated with a pull request, click on the "Artifacts" tab, and select a static file to open
+and preview in your browesr.
+

--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,9 @@
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
 title: SORSE20 - International Series of Online Research Software Events
+baseurl: "/SORSE20"  # for testing, also check .circleci/circle_urls.sh 
+url: "https://de-rse.org"
+repository: DE-RSE/SORSE20
 email: SET-EMAIL-IN-_config.yml
 description: >- # this means to ignore newlines until "baseurl:"
   Series of Online Research Software Events 2020
@@ -33,20 +36,15 @@ timezone: # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 
 include:
   - _pages
+
+# Exclude these files from production site
 exclude:
   - scripts
-
-# Exclude from processing.
-# The following items will not be processed, by default. Create a custom list
-# to override the default setting.
-# exclude:
-#   - Gemfile
-#   - Gemfile.lock
-#   - node_modules
-#   - vendor/bundle/
-#   - vendor/cache/
-#   - vendor/gems/
-#   - vendor/ruby/
+  - _site
+  - Gemfile
+  - Gemfile.lock
+  - README.md
+  - vendor
 
 # Plugins (previously gems:)
 plugins:


### PR DESCRIPTION
This PR will address #29, adding a circle build and preview for the site. CircleCI will need to have the repository connected before we can test this out. I'll do any updates to the PR depending on how the preview works - notably the _config.yml doesn't have a baseurl here so I attempt to add it with the circle url that should render.

Signed-off-by: vsoch <vsochat@stanford.edu>