### PR TITLE
Use de-RSE logo from github repo

### DIFF
--- a/_data/committee/national_chapters.yml
+++ b/_data/committee/national_chapters.yml
@@ -6,7 +6,7 @@ deRSE:
   long_name: de-RSE e.V. - Society for Research Software
   internal: /contact/#deRSE
   twitter: RSE_de
-  avatar: https://de-rse.org/assets/img/site/rse.png
+  avatar: https://raw.githubusercontent.com/DE-RSE/logo-association/master/de-RSE-logo-only-colour.svg
 ukRSE:
   name: UK RSE
   avatar: https://society-rse.org/wp-content/uploads/2019/07/Soc_RSE_master_logo-1.png


### PR DESCRIPTION
because the one from the website is blurred

closes #18 