### PR TITLE
Add new de-RSE logo

### DIFF
--- a/_data/committee/national_chapters.yml
+++ b/_data/committee/national_chapters.yml
@@ -6,7 +6,7 @@ deRSE:
   long_name: de-RSE e.V. - Society for Research Software
   internal: /contact/chapters/#deRSE
   twitter: RSE_de
-  avatar: https://de-rse.org/assets/img/site/rse.png
+  avatar: https://raw.githubusercontent.com/DE-RSE/logo-association/master/de-RSE-logo-only-colour.svg
 ukRSE:
   name: UK RSE
   avatar: https://society-rse.org/wp-content/uploads/2019/07/Soc_RSE_master_logo-1.png


### PR DESCRIPTION
The logo is blurry in the card layout. This PR uses the raw SVG file straight from GitHub to fix #18.