### PR TITLE
Add monthly posts

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -50,3 +50,11 @@ programme:
         url: "/programme/talks/"
       - title: Workshops
         url: "/programme/workshops/"
+
+footer:
+  - title: Programme
+    url: "/programme/"
+  - title: Contact
+    url: "/contact/"
+  - title: Archive
+    url: "/archive/"

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -18,7 +18,7 @@
 
 <div class="page__footer-nav">
   {% for link in site.data.navigation.footer %}
-    <a href="{{ link.url }}" rel="nofollow noopener noreferrer">{{ link.title }}</a>
+    <a href="{% include fix-link.html link=link.url %}" rel="nofollow noopener noreferrer">{{ link.title }}</a>
   {% endfor %}
 </div>
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,25 @@
+<div class="page__footer-follow">
+  <ul class="social-icons">
+    {% if site.data.ui-text[site.locale].follow_label %}
+      <li><strong>{{ site.data.ui-text[site.locale].follow_label }}</strong></li>
+    {% endif %}
+
+    {% if site.footer.links %}
+      {% for link in site.footer.links %}
+        {% if link.label and link.url %}
+          <li><a href="{{ link.url }}" rel="nofollow noopener noreferrer"><i class="{{ link.icon | default: 'fas fa-link' }}" aria-hidden="true"></i> {{ link.label }}</a></li>
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+
+    <li><a href="{% if site.atom_feed.path %}{{ site.atom_feed.path }}{% else %}{{ '/feed.xml' | relative_url }}{% endif %}"><i class="fas fa-fw fa-rss-square" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].feed_label | default: "Feed" }}</a></li>
+  </ul>
+</div>
+
+<div class="page__footer-nav">
+  {% for link in site.data.navigation.footer %}
+    <a href="{{ link.url }}" rel="nofollow noopener noreferrer">{{ link.title }}</a>
+  {% endfor %}
+</div>
+
+<div class="page__footer-copyright">&copy; {{ site.time | date: '%Y' }} {{ site.name | default: site.title }}. {{ site.data.ui-text[site.locale].powered_by | default: "Powered by" }} <a href="https://jekyllrb.com" rel="nofollow">Jekyll</a> &amp; <a href="https://mademistakes.com/work/minimal-mistakes-jekyll-theme/" rel="nofollow">Minimal Mistakes</a>.</div>

--- a/_layouts/monthly-posts.html
+++ b/_layouts/monthly-posts.html
@@ -1,0 +1,29 @@
+---
+layout: archive
+---
+
+{{ content }}
+
+<ul class="taxonomy__index">
+  {% assign postsInMonth = site.posts | group_by_exp: 'post', 'post.date | date: "%B %Y"' %}
+  {% for month in postsInMonth %}
+    <li>
+      <a href="#{{ month.name }}">
+        <strong>{{ month.name }}</strong> <span class="taxonomy__count">{{ month.items | size }}</span>
+      </a>
+    </li>
+  {% endfor %}
+</ul>
+
+{% assign postsByMonth = site.posts | group_by_exp: 'post', 'post.date | date: "%B %Y"' %}
+{% for month in postsByMonth %}
+  <section id="{{ month.name }}" class="taxonomy__section">
+    <h2 class="archive__subtitle">{{ month.name }}</h2>
+    <div class="entries-{{ page.entries_layout | default: 'list' }}">
+      {% for post in month.items %}
+        {% include archive-single.html type=page.entries_layout %}
+      {% endfor %}
+    </div>
+    <a href="#page-title" class="back-to-top">{{ site.data.ui-text[site.locale].back_to_top | default: 'Back to Top' }} &uarr;</a>
+  </section>
+{% endfor %}

--- a/_pages/archive.md
+++ b/_pages/archive.md
@@ -2,5 +2,4 @@
 title: "Posts by Year"
 permalink: /archive/
 layout: monthly-posts
-entries_layout: grid
 ---

--- a/_pages/archive.md
+++ b/_pages/archive.md
@@ -1,12 +1,6 @@
 ---
-title: Posts Archive
+title: "Posts by Year"
 permalink: /archive/
+layout: monthly-posts
+entries_layout: grid
 ---
-
-{% for post in site.posts %}{% capture nowunix %}{{'now' | date: '%s'}}{% endcapture %}
-{% assign yearDate = post.date | date: "%Y" %}
-{% if yearDate != myDate %}{% if added %}</ul>{% endif %}
-<h1 style="margin-top:20px; margin-bottom:10px">{{ yearDate }}</h1>
-<ul>{% assign myDate = yearDate %}{% endif %}
-   <li><a href="{{ site.url }}{{ post.url }}">{{ post.title }}</a> {% assign added = true %}</li>
- {% if forloop.last %}</ul>{% endif %}{% endfor %}

--- a/_pages/archive.md
+++ b/_pages/archive.md
@@ -1,5 +1,5 @@
 ---
-title: "Posts by Year"
+title: "Posts by Month"
 permalink: /archive/
 layout: monthly-posts
 ---

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -31,3 +31,11 @@ a.missing:link {
 a.missing:visited {
   color: rgba(255, 0, 0, 1.0);
 }
+
+.page__footer-nav {
+  font-size: $type-size-7;
+  margin-bottom: 10px;
+  a {
+    padding: 1em;
+  }
+}


### PR DESCRIPTION
Concerning the first questions in #60

> where to put the link to post archive (and how to customize rendering the listing, e.g., adding categories, or even rendering different pages or sections for different categories)

I'd make a small navigation in the footer of the page where we add the post archive (see https://github.com/RSE-leaders/SORSE20/commit/075ac320c006f9357c0026b9407dfc9a081f5319 and the screenshot below). Do you think this is okay?  

![image](https://user-images.githubusercontent.com/9960249/84506048-045a9e00-acbf-11ea-9cfd-926fb393df7d.png)

minimal mistakes comes with several [layouts for post archives](https://mmistakes.github.io/minimal-mistakes/docs/layouts/#archive-layout), so we could easily make create a navigation for the post archive and make separate subpages, one archive grouped by month (https://github.com/RSE-leaders/SORSE20/commit/f4e4b28240cbc09227bc53430a2d3f7232762a91, year does not really make sense as everything is happening in 2020), another by category, and another by tag.



