### PR TITLE
Elastic social buttons in cards

### DIFF
--- a/_includes/card.html
+++ b/_includes/card.html
@@ -24,22 +24,22 @@
     {% endif %}
     <p class="card-content">
       {% if info.website %}
-      <a href="{{ info.website }}"><span><i class="fas fa-globe"></i></span></a>
+      <a href="{{ info.website }}"><span><i class="elastic-fai fas fa-globe"></i></span></a>
       {% endif %}
       {% if info.orcid %}
-      <a href="https://orcid.org/{{ info.orcid }}"><span><i class="fab fa-orcid"></i></span></a>
+      <a href="https://orcid.org/{{ info.orcid }}"><span><i class="elastic-fai fab fa-orcid"></i></span></a>
       {% endif %}
       {% if info.github %}
-      <a href="https://github.com/{{ info.github }}"><span><i class="fab fa-fw fa-github"></i></span></a>
+      <a href="https://github.com/{{ info.github }}"><span><i class="elastic-fai fab fa-fw fa-github"></i></span></a>
       {% endif %}
       {% if info.email %}
-      <a href="mailto:{{ info.email }}" title="{{ info.email }}"><span><i class="fas fa-envelope"></i></span></a>
+      <a href="mailto:{{ info.email }}" title="{{ info.email }}"><span><i class="elastic-fai fas fa-envelope"></i></span></a>
       {% endif %}
       {% if info.twitter %}
-      <a href="https://twitter.com/{{ info.twitter }}"><span><i class="fab fa-twitter"></i></span></a>
+      <a href="https://twitter.com/{{ info.twitter }}"><span><i class="elastic-fai fab fa-twitter"></i></span></a>
       {% endif %}
       {% if info.internal %}
-      <a href="{{ site.baseurl }}{{ info.internal }}"><span><i class="fas fa-link"></i></span></a>
+      <a href="{{ site.baseurl }}{{ info.internal }}"><span><i class="elastic-fai fas fa-link"></i></span></a>
       {% endif %}
       <br>
       {% for team in info.teams %}

--- a/_sass/card.scss
+++ b/_sass/card.scss
@@ -9,12 +9,10 @@
 
 	& .elastic-fai {
 		font-size: $type-size-1;
+		margin-bottom: 0.5em;
 
-		@include breakpoint($small) {
-			font-size: $type-size-3;
-		}
 		@include breakpoint($medium) {
-			font-size: $type-size-4;
+			font-size: $type-size-2;
 		}
 		@include breakpoint($large) {
 			font-size: $type-size-5;

--- a/_sass/card.scss
+++ b/_sass/card.scss
@@ -6,6 +6,20 @@
 	border-radius: 5px; /* 5px rounded corners */
 	display: inline-block;
 	margin: 10px;
+
+	& .elastic-fai {
+		font-size: $type-size-1;
+
+		@include breakpoint($small) {
+			font-size: $type-size-3;
+		}
+		@include breakpoint($medium) {
+			font-size: $type-size-4;
+		}
+		@include breakpoint($large) {
+			font-size: $type-size-5;
+		}
+	}
 }
 
 /* On mouse-over, add a deeper shadow */


### PR DESCRIPTION
I added specific font sizes by using the different breakpoints of the minimal mistakes theme. Base size for everything smaller than ``600px`` is currently defined with ``$type-size-1``. For bigger screens the icons get smaller.

I am not used the the ``breakpoints`` mixin. So if anybody knows how to do this more effectively, please go ahead :)

<img width="496" alt="Screenshot 2020-06-12 at 17 29 41" src="https://user-images.githubusercontent.com/8090701/84519491-75f01780-acd2-11ea-83f6-f1f7675f037a.png">

Closes #48.
