### PR TITLE
Use news category and add more archive pages

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -51,6 +51,16 @@ programme:
       - title: Workshops
         url: "/programme/workshops/"
 
+archive:
+  - title: "Posts"
+    children:
+      - title: "by month"
+        url: /archive/
+      - title: "by category"
+        url: /archive/categories
+      - title: "by tag"
+        url: /archive/tags
+
 footer:
   - title: Programme
     url: "/programme/"

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -11,6 +11,8 @@ news:
     children:
       - title: "Call for Contributions"
         url: "/programme/call-for-contributions/"
+  - title: News
+    url: /news/
 
 contact:
   - title: "Contact"

--- a/_pages/archive/archive.md
+++ b/_pages/archive/archive.md
@@ -2,4 +2,6 @@
 title: "Posts by Month"
 permalink: /archive/
 layout: monthly-posts
+sidebar:
+  nav: "archive"
 ---

--- a/_pages/archive/categories.md
+++ b/_pages/archive/categories.md
@@ -1,0 +1,7 @@
+---
+title: "Posts by Category"
+permalink: /archive/categories
+layout: categories
+sidebar:
+  nav: "archive"
+---

--- a/_pages/archive/categories.md
+++ b/_pages/archive/categories.md
@@ -1,6 +1,6 @@
 ---
 title: "Posts by Category"
-permalink: /archive/categories
+permalink: /archive/categories/
 layout: categories
 sidebar:
   nav: "archive"

--- a/_pages/archive/tags.md
+++ b/_pages/archive/tags.md
@@ -1,0 +1,7 @@
+---
+title: "Posts by Tag"
+permalink: /archive/tags
+layout: tags
+sidebar:
+  nav: "archive"
+---

--- a/_pages/archive/tags.md
+++ b/_pages/archive/tags.md
@@ -1,6 +1,6 @@
 ---
 title: "Posts by Tag"
-permalink: /archive/tags
+permalink: /archive/tags/
 layout: tags
 sidebar:
   nav: "archive"

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -71,17 +71,17 @@ See our [schedule of events](){: .missing} for details of what’s coming up.
 ## Do I need to pay to attend SORSE events?
 No! It’s completely free to the community with the national RSE Groups from many countries collaborating to bring this to you.
 
-<h3>Announcements</h3>
+### News
 
 {% if paginator %}
-  {% assign posts = paginator.posts %}
+  {% assign posts = paginator.categories["news"] %}
 {% else %}
-  {% assign posts = site.posts %}
+  {% assign posts = site.categories["news"] %}
 {% endif %}
 
-{% for post in posts %}{% if post.tags contains "announcement"%}
+{% for post in posts %}
   {% include archive-single.html %}
-{% endif %}{% endfor %}
+{% endfor %}
 
 {% include paginator.html %}
 

--- a/_pages/news.md
+++ b/_pages/news.md
@@ -1,0 +1,6 @@
+---
+title: "News"
+permalink: /news/
+layout: category
+taxonomy: news
+---

--- a/_pages/news.md
+++ b/_pages/news.md
@@ -3,4 +3,8 @@ title: "News"
 permalink: /news/
 layout: category
 taxonomy: news
+sidebar:
+  nav: "news"
+toc: true
+toc_sticky: true
 ---

--- a/_posts/announcements/2020-05-28-example.md
+++ b/_posts/announcements/2020-05-28-example.md
@@ -1,6 +1,7 @@
 ---
 title: This is an announcement post!
 tags: [announcement]
+category: news
 ---
 
 # Fecisses seraque barbaricoque dixit


### PR DESCRIPTION
This PR answers the other open questions in #60:

> how to format the url for posts (if we add a category to the frontend matter of the posts and use that instead of the tag then we could much better represent this in the url.

I added a *news* category that shall be used for announcements and stuff like that. Furthermore, I added a `/news/` page that simply displays all posts that fall under this category

https://93-267395254-gh.circle-artifacts.com/0/SORSE20/index.html#news
https://93-267395254-gh.circle-artifacts.com/0/SORSE20/news/index.html

I also added this news page to the sidebar

---

The other changes are a supplement to #61. As I mentioned there already, I created subpages for posts by category, month and tag

https://93-267395254-gh.circle-artifacts.com/0/SORSE20/archive/index.html
https://93-267395254-gh.circle-artifacts.com/0/SORSE20/archive/categories/index.html
https://93-267395254-gh.circle-artifacts.com/0/SORSE20/archive/tags/index.html

I'd later also add a page for events here to make an events archive.