### PR TITLE
Move front matter content to FAQs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -98,3 +98,16 @@ defaults:
     values:
       layout: single
       author_profile: false
+  # _faq
+  - scope:
+      path: ""
+      type: faq
+    values:
+      layout: single
+      author_profile: false
+      share: true
+
+collections:
+  faq:
+    output: true
+    permalink: /:collection/:path/

--- a/_config.yml
+++ b/_config.yml
@@ -106,6 +106,8 @@ defaults:
       layout: single
       author_profile: false
       share: true
+      sidebar:
+        nav: faq
 
 collections:
   faq:

--- a/_config.yml
+++ b/_config.yml
@@ -105,7 +105,7 @@ defaults:
     values:
       layout: single
       author_profile: false
-      share: true
+      share: false
       sidebar:
         nav: faq
 

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,10 +1,10 @@
 main:
-  - title: About
-    url: /faq/#about
   - title: "Programme"
     url: /programme/call-for-contributions/ # Change to /programme/ once there is a programme page
   - title: "Contact"
     url: /contact/
+  - title: About
+    url: /faq/#about
   - title: "For delegates"
     url: /delegates/code-of-conduct/ # Change to /delegates/ once there is a delegates page
 

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -11,6 +11,8 @@ news:
     children:
       - title: "Call for Contributions"
         url: "/programme/call-for-contributions/"
+  - title: FAQ
+    url: /faq/
 
 contact:
   - title: "Contact"

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,4 +1,6 @@
 main:
+  - title: About
+    url: /faq/#about
   - title: "Programme"
     url: /programme/call-for-contributions/ # Change to /programme/ once there is a programme page
   - title: "Contact"
@@ -13,6 +15,11 @@ news:
         url: "/programme/call-for-contributions/"
   - title: FAQ
     url: /faq/
+    children:
+      - title: About
+        url: /faq/#about
+      - title: How it works
+        url: /faq/#how-it-work
 
 contact:
   - title: "Contact"
@@ -28,6 +35,15 @@ contact:
 delegates:
   - title: "Code of Conduct"
     url: /delegates/code-of-conduct/
+
+faq:
+  - title: FAQ
+    url: /faq/
+    children:
+      - title: About
+        url: /faq/#about
+      - title: How it works
+        url: /faq/#how-it-works
 
 programme:
   - title: "Programme"

--- a/_faq/about/01-what-is-sorse.md
+++ b/_faq/about/01-what-is-sorse.md
@@ -1,0 +1,19 @@
+---
+title: "What is SORSE? - Series of Online Research Software Events"
+permalink: /faq/about/what-is-sorse
+tags:
+  - About
+---
+
+With the cancellation of several international Research Software Engineering (RSE) community events as a result of the COVID-19 pandemic, RSEs worldwide are facing a lack of opportunities to engage with their wider community. To address this challenge, SORSE has been launched by an [international committee](contact/#international-committee-members) to provide an opportunity for RSEs to develop and grow their skills, build new collaborations and engage with RSEs worldwide. Until we can meet again in person, SORSE (pronounced ‘Source’), will bridge the gap and be the source of interesting and engaging events.
+
+This is an open call to all RSEs and anyone involved with research software, worldwide, to propose talks, workshops and other types of online events.
+
+The aims of the event series:
+
+- To create and deliver a range of permanent resources for RSEs to develop both technical and soft skills, giving them the opportunity to contribute to and learn from the series
+- To develop and share knowledge about the field of research software e.g. how is Research Software built and used, how do we learn the skills to improve its sustainability and reliability, how do we apply it in our research, demonstrating its importance to research,
+- To encourage involvement with the collection efforts of personal and technical RSE journeys (Podcasts etc) to better understand the makeup and demographics of our community and promote diversity and inclusivity
+- To develop new research relationships that may lead to future collaborations and strengthen international links within the community
+- To provide a ‘Show and Tell’ opportunity for RSEs to present their ideas and their work to an international audience
+- To maintain the momentum of the RSE movement by helping to build and support the national and international Research Software Communities

--- a/_faq/about/02-format-of-sorse.md
+++ b/_faq/about/02-format-of-sorse.md
@@ -1,0 +1,23 @@
+---
+title: What is the format of SORSE?
+permalink: /faq/about/format-of-sorse
+tags:
+  - About
+---
+SORSE will deliver a range of different types of events in ideally a 1 hour or 2 hour time slot (but the event could be shorter), followed by time for networking and discussion with other participants. We will organise an event every two weeks in English with the option of a national event (in the mother tongue) taking place in the alternating weeks.  We hope that this series will be popular so that we can continue it into 2021.
+
+We’re an [informal community](contact/#international-committee-members) and we know life is busy and very different at the moment, so feel free to join events when you can and leave when you need to.
+
+Event types include:
+
+(Descriptions will be added by the programme team soon, here we should link to the corresponding subteam pages)
+{: .notice--warning}
+
+- Talks - both technical and soft skills
+- Workshops
+- [Software demos]({{ site.baseurl }}{{ site.data.committee.programme_teams.software_demo.internal }})
+- Poster sessions with Lightning talks
+- Panel & Discussion session
+- Sprints
+
+Along with these events above, we will be inviting guest speakers from around the world to join us and we’re happy to take suggestions for guest speakers via the [Topic Bazaar](){: .missing}.

--- a/_faq/about/03-costs.md
+++ b/_faq/about/03-costs.md
@@ -1,0 +1,7 @@
+---
+title: Do I need to pay to attend SORSE events?
+permalink: /faq/about/costs
+tags:
+  - About
+---
+No! It’s completely free to the community with the national RSE Groups from many countries collaborating to bring this to you.

--- a/_faq/howto/attendance.md
+++ b/_faq/howto/attendance.md
@@ -1,0 +1,8 @@
+---
+title: How can I attend an event
+tags:
+  - How it works
+---
+Webinars allow speakers to present, share their screen or webcam and attendees will have the opportunity to ask questions and answer polls via the built-in Q&A system of Zoom webinars. Questions will then be read out in the Q&A part of the session and answered live by the speakers.  Events will be recorded so that they can be run multiple times to suit different time zones and encourage communities to come together to network within different regions.  A presenter can pre-record their event if they wish and the programme team will provide assistance with this process.
+For certain events, like workshops and poster sessions, we will be using Zoom breakout rooms which allow for direct interaction with the speaker via audio and video.
+We will also use [Chat system tbc](){: .missing } to allow continuing discussions that will remain available after each individual event.

--- a/_faq/howto/contribute-blog-posts.md
+++ b/_faq/howto/contribute-blog-posts.md
@@ -1,0 +1,6 @@
+---
+title: Can I write blogs?
+tags:
+  - How it works
+---
+We welcome blog posts for the SORSE website blog at [https://researchsoftware.org/blog](){: .missing }. These may be linked to SORSE events such as talks, posters or software demos, or they can be standalone. We are happy to accept blog posts that will appeal to a general audience as well as those that are tailored to a more specialist technical audience.

--- a/_faq/howto/get-involved.md
+++ b/_faq/howto/get-involved.md
@@ -1,0 +1,10 @@
+---
+title: How do I get involved?
+tags:
+  - How it works
+---
+Were you going to submit something to an RSE conference this year? Do you have a project you’d like to share? Is there a talk/workshop/panel you’d like to see happen? Then you’ve found the right place!
+
+You can make a contribution to one of the event types (see above), see our [call for submissions](){: .missing} and/or suggest an event in the [Topic Bazaar](){: .missing} that you’d like to see in the series. We’re looking for both technical and soft skills and there are no set themes this year but if a theme emerges, we may group those events together to create a half day event or a run of events over a few weeks.
+
+We encourage submissions from all time zones and will schedule events on a day and at a time that suits the presenter.  Events will be recorded so that they can be run multiple times to suit different time zones and encourage those communities to come together to network.  

--- a/_faq/howto/submission.md
+++ b/_faq/howto/submission.md
@@ -1,0 +1,8 @@
+---
+title: How will the submission process work?
+tags:
+  - How it works
+---
+The call for submissions will remain open and there will be a rolling monthly deadline following which all submissions received over the previous month will be sent for review by the Programme Committee. The call is open to anyone wanting to propose a research software-related talk or event from anywhere in the world, regardless of your role.   Upcoming submission deadlines are all detailed on the [submissions page](){: .missing}. Each submission deadline will have an earliest event date when events submitted prior to that deadline can take place. You can propose an event for any date or range of dates beyond this.
+
+See our [schedule of events](){: .missing} for details of what’s coming up.

--- a/_faq/howto/tools.md
+++ b/_faq/howto/tools.md
@@ -1,0 +1,6 @@
+---
+title: What tools are we using?
+tags:
+  - How it works
+---
+We will be using [Zoom](){: .missing } as well as live streaming the events via YouTube Live (no registration is required to view events via either platform).

--- a/_includes/documents-subcollection.html
+++ b/_includes/documents-subcollection.html
@@ -1,0 +1,21 @@
+{% assign entries = include.collection %}
+
+{% if include.sort_by == 'title' %}
+  {% if include.sort_order == 'reverse' %}
+    {% assign entries = entries | sort: 'title' | reverse %}
+  {% else %}
+    {% assign entries = entries | sort: 'title' %}
+  {% endif %}
+{% elsif include.sort_by == 'date' %}
+  {% if include.sort_order == 'reverse' %}
+    {% assign entries = entries | sort: 'date' | reverse %}
+  {% else %}
+    {% assign entries = entries | sort: 'date' %}
+  {% endif %}
+{% endif %}
+
+{%- for post in entries -%}
+  {%- unless post.hidden -%}
+    {% include archive-single.html %}
+  {%- endunless -%}
+{%- endfor -%}

--- a/_layouts/collection-tags.html
+++ b/_layouts/collection-tags.html
@@ -10,7 +10,7 @@ layout: archive
 <ul class="taxonomy__index">
   {% for tag in group_names %}
     <li>
-      <a href="#{{ tag }}">
+      <a href="#{{ tag | slugify | downcase }}">
         <strong>{{ tag }}</strong> <span class="taxonomy__count">{{ group_items[forloop.index0] | size }}</span>
       </a>
     </li>
@@ -20,6 +20,8 @@ layout: archive
 
 {% for tag in group_names %}
   {% assign posts = group_items[forloop.index0] %}
-  <h2>{{ tag }}</h2>
-    {% include documents-subcollection.html collection=posts sort_by=page.sort_by sort_order=page.sort_order type=page.entries_layout %}
+  <section id="{{ tag | slugify | downcase }}" class="taxonomy__section">
+    <h2>{{ tag }}</h2>
+      {% include documents-subcollection.html collection=posts sort_by=page.sort_by sort_order=page.sort_order type=page.entries_layout %}
+  </section>
 {% endfor %}

--- a/_layouts/collection-tags.html
+++ b/_layouts/collection-tags.html
@@ -1,0 +1,25 @@
+---
+layout: archive
+---
+
+{{ content }}
+
+{% assign collection = site[page.collection] %}
+{% include group-by-array collection=collection field="tags" %}
+
+<ul class="taxonomy__index">
+  {% for tag in group_names %}
+    <li>
+      <a href="#{{ tag }}">
+        <strong>{{ tag }}</strong> <span class="taxonomy__count">{{ group_items[forloop.index0] | size }}</span>
+      </a>
+    </li>
+  {% endfor %}
+</ul>
+
+
+{% for tag in group_names %}
+  {% assign posts = group_items[forloop.index0] %}
+  <h2>{{ tag }}</h2>
+    {% include documents-subcollection.html collection=posts sort_by=page.sort_by sort_order=page.sort_order type=page.entries_layout %}
+{% endfor %}

--- a/_pages/faq.md
+++ b/_pages/faq.md
@@ -4,4 +4,6 @@ permalink: /faq/
 collection: faq
 layout: collection-tags
 classes: wide
+sidebar:
+  nav: faq
 ---

--- a/_pages/faq.md
+++ b/_pages/faq.md
@@ -1,0 +1,7 @@
+---
+title: FAQ
+permalink: /faq/
+collection: faq
+layout: collection-tags
+classes: wide
+---

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -10,6 +10,6 @@ author_profile: false
 This document is work in progress!
 {: .notice--danger}
 
-Welcome to SORSE20 - A **S** eries of **O** nline **R**esearch **S**oftware **E**vents - our international answer to the COVID-19-induced cancellation of many national RSE conferences. We want to provide an opportunity for RSEs to develop and grow their skills, build new collaborations and engage with RSEs worldwide. This is an open call to all RSEs and anyone involved with research software, worldwide, to propose talks, workshops and other types of online events.
+Welcome to SORSE20 - A **S**eries of **O**nline **R**esearch **S**oftware **E**vents - our international answer to the COVID-19-induced cancellation of many national RSE conferences. We want to provide an opportunity for RSEs to develop and grow their skills, build new collaborations and engage with RSEs worldwide. This is an open call to all RSEs and anyone involved with research software, worldwide, to propose talks, workshops and other types of online events.
 
 Any questions, read [more](faq/about/what-is-sorse) or [get in touch](contact/)!

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -10,66 +10,6 @@ author_profile: false
 This document is work in progress!
 {: .notice--danger}
 
-## What is SORSE? - Series of Online Research Software Events
+Welcome to SORSE20 - A **S** eries of **O** nline **R**esearch **S**oftware **E**vents - our international answer to the COVID-19-induced cancellation of many national RSE conferences. We want to provide an opportunity for RSEs to develop and grow their skills, build new collaborations and engage with RSEs worldwide. This is an open call to all RSEs and anyone involved with research software, worldwide, to propose talks, workshops and other types of online events.
 
-With the cancellation of several international Research Software Engineering (RSE) community events as a result of the COVID-19 pandemic, RSEs worldwide are facing a lack of opportunities to engage with their wider community. To address this challenge, SORSE has been launched by an [international committee](contact/#international-committee-members) to provide an opportunity for RSEs to develop and grow their skills, build new collaborations and engage with RSEs worldwide. Until we can meet again in person, SORSE (pronounced ‘Source’), will bridge the gap and be the source of interesting and engaging events.
-
-This is an open call to all RSEs and anyone involved with research software, worldwide, to propose talks, workshops and other types of online events.
-
-The aims of the event series:
-
-- To create and deliver a range of permanent resources for RSEs to develop both technical and soft skills, giving them the opportunity to contribute to and learn from the series
-- To develop and share knowledge about the field of research software e.g. how is Research Software built and used, how do we learn the skills to improve its sustainability and reliability, how do we apply it in our research, demonstrating its importance to research,
-- To encourage involvement with the collection efforts of personal and technical RSE journeys (Podcasts etc) to better understand the makeup and demographics of our community and promote diversity and inclusivity
-- To develop new research relationships that may lead to future collaborations and strengthen international links within the community
-- To provide a ‘Show and Tell’ opportunity for RSEs to present their ideas and their work to an international audience
-- To maintain the momentum of the RSE movement by helping to build and support the national and international Research Software Communities
-
-## What is the format of SORSE?
-SORSE will deliver a range of different types of events in ideally a 1 hour or 2 hour time slot (but the event could be shorter), followed by time for networking and discussion with other participants. We will organise an event every two weeks in English with the option of a national event (in the mother tongue) taking place in the alternating weeks.  We hope that this series will be popular so that we can continue it into 2021.
-
-We’re an [informal community](contact/#international-committee-members) and we know life is busy and very different at the moment, so feel free to join events when you can and leave when you need to.
-
-Event types include:
-
-(Descriptions will be added by the programme team soon, here we should link to the corresponding subteam pages)
-{: .notice--warning}
-
-- Talks - both technical and soft skills
-- Workshops
-- [Software demos]({{ site.baseurl }}{{ site.data.committee.programme_teams.software_demo.internal }})
-- Poster sessions with Lightning talks
-- Panel & Discussion session
-- Sprints
-
-Along with these events above, we will be inviting guest speakers from around the world to join us and we’re happy to take suggestions for guest speakers via the [Topic Bazaar](){: .missing}.
-
-### Blog posts
-We welcome blog posts for the SORSE website blog at [https://researchsoftware.org/blog](){: .missing }. These may be linked to SORSE events such as talks, posters or software demos, or they can be standalone. We are happy to accept blog posts that will appeal to a general audience as well as those that are tailored to a more specialist technical audience.
-
-## What tools are we using?
-We will be using [Zoom](){: .missing } as well as live streaming the events via YouTube Live (no registration is required to view events via either platform).
-
-### Attendee interaction during talks
-Webinars allow speakers to present, share their screen or webcam and attendees will have the opportunity to ask questions and answer polls via the built-in Q&A system of Zoom webinars. Questions will then be read out in the Q&A part of the session and answered live by the speakers.  Events will be recorded so that they can be run multiple times to suit different time zones and encourage communities to come together to network within different regions.  A presenter can pre-record their event if they wish and the programme team will provide assistance with this process.
-For certain events, like workshops and poster sessions, we will be using Zoom breakout rooms which allow for direct interaction with the speaker via audio and video.
-We will also use [Chat system tbc](){: .missing } to allow continuing discussions that will remain available after each individual event.
-
-
-## How do I get involved?
-Were you going to submit something to an RSE conference this year? Do you have a project you’d like to share? Is there a talk/workshop/panel you’d like to see happen? Then you’ve found the right place!
-
-You can make a contribution to one of the event types (see above), see our [call for submissions](){: .missing} and/or suggest an event in the [Topic Bazaar](){: .missing} that you’d like to see in the series. We’re looking for both technical and soft skills and there are no set themes this year but if a theme emerges, we may group those events together to create a half day event or a run of events over a few weeks.
-
-We encourage submissions from all time zones and will schedule events on a day and at a time that suits the presenter.  Events will be recorded so that they can be run multiple times to suit different time zones and encourage those communities to come together to network.  
-
-### How will the submission process work?
-The call for submissions will remain open and there will be a rolling monthly deadline following which all submissions received over the previous month will be sent for review by the Programme Committee. The call is open to anyone wanting to propose a research software-related talk or event from anywhere in the world, regardless of your role.   Upcoming submission deadlines are all detailed on the [submissions page](){: .missing}. Each submission deadline will have an earliest event date when events submitted prior to that deadline can take place. You can propose an event for any date or range of dates beyond this.
-
-See our [schedule of events](){: .missing} for details of what’s coming up.
-
-
-## Do I need to pay to attend SORSE events?
-No! It’s completely free to the community with the national RSE Groups from many countries collaborating to bring this to you.
-
-Any questions, please [get in touch](contact/)!
+Any questions, read [more](faq/about/what-is-sorse) or [get in touch](contact/)!


### PR DESCRIPTION
This PR covers the third point in https://github.com/RSE-leaders/SORSE20/issues/15#issuecomment-642940625, moving the current content of the landing page into an FAQ section.

If we merge this PR, we 

*  replace the current text on the landing page by the welcome text mentioned in https://github.com/RSE-leaders/SORSE20/issues/15#issuecomment-642934049
* create an [FAQ page](https://99-267395254-gh.circle-artifacts.com/0/SORSE20/faq/index.html) that is automatically populated and sorted by the tags of the corresponding FAQ 
* sort the former questions from the landing page into [About](https://99-267395254-gh.circle-artifacts.com/0/SORSE20/faq/index.html#about) and [How it works](https://99-267395254-gh.circle-artifacts.com/0/SORSE20/faq/index.html#how-it-works) sections

As mentioned in https://github.com/RSE-leaders/SORSE20/issues/15#issuecomment-641529419, I feel like the current questions rather read like an FAQ than an about. But I understand that an *About* section is one common way to get to know a web page. Therefore I also added the corresponding FAQ-section to the main nav. 

![image](https://user-images.githubusercontent.com/9960249/84580583-7541a900-add8-11ea-8d84-a64c58a81f19.png)

@TeriForey: Do you think this is okay? 