### PR TITLE
Change link to 'read more' on homepage to FAQ landing

### DIFF
--- a/_pages/home.md
+++ b/_pages/home.md
@@ -12,4 +12,4 @@ This document is work in progress!
 
 Welcome to SORSE20 - A **S**eries of **O**nline **R**esearch **S**oftware **E**vents - our international answer to the COVID-19-induced cancellation of many national RSE conferences. We want to provide an opportunity for RSEs to develop and grow their skills, build new collaborations and engage with RSEs worldwide. This is an open call to all RSEs and anyone involved with research software, worldwide, to propose talks, workshops and other types of online events.
 
-Any questions, read [more](faq/about/what-is-sorse) or [get in touch](contact/)!
+Any questions, read [more](faq/) or [get in touch](contact/)!


### PR DESCRIPTION
Changes the 'read more' link on the home page to point to FAQ https://rse-leaders.github.io/SORSE20/faq/