### PR TITLE
Add FAQ to footer navigation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -96,5 +96,7 @@ footer:
     url: "/programme/"
   - title: Contact
     url: "/contact/"
+  - title: FAQ
+    url: "/faq/"
   - title: Archive
     url: "/archive/"


### PR DESCRIPTION
This PR combines the footer of #60 with the FAQ of #64 

![image](https://user-images.githubusercontent.com/9960249/84688079-02067700-af3f-11ea-83e3-4c042f8b5482.png)

anyone who is willing to review this, visit https://117-267395254-gh.circle-artifacts.com/0/SORSE20/index.html for instance