### PR TITLE
Add git metadata to website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _site
 .sass-cache
 .jekyll-metadata
 Gemfile.lock
+.git-metadata

--- a/Gemfile
+++ b/Gemfile
@@ -14,4 +14,5 @@ group :jekyll_plugins do
   gem "jemoji"
   gem "jekyll-include-cache"
   gem "jekyll-algolia"
+  gem 'jekyll-git_metadata'
 end

--- a/_config.yml
+++ b/_config.yml
@@ -56,6 +56,9 @@ plugins:
   - jemoji
   - jekyll-include-cache
 
+github:
+  repository_url: https://github.com/RSE-leaders/SORSE20
+
 author:
   name   : "SORSE"
   avatar : "/assets/images/bio-photo.jpg"

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -22,4 +22,6 @@
   {% endfor %}
 </div>
 
+<div class="page__footer-git">Build at revision <a href="https://github.com/RSE-leaders/SORSE20/tree/{{ site.git.last_commit.long_sha }}" data-proofer-ignore><code>{{ site.git.last_commit.short_sha }}</code></a> on {{ site.git.last_commit.commit_date | date_to_string: "ordinal", "US" }}.</div>
+
 <div class="page__footer-copyright">&copy; {{ site.time | date: '%Y' }} {{ site.name | default: site.title }}. {{ site.data.ui-text[site.locale].powered_by | default: "Powered by" }} <a href="https://jekyllrb.com" rel="nofollow">Jekyll</a> &amp; <a href="https://mademistakes.com/work/minimal-mistakes-jekyll-theme/" rel="nofollow">Minimal Mistakes</a>.</div>

--- a/_includes/footer/custom.html
+++ b/_includes/footer/custom.html
@@ -1,3 +1,4 @@
-<button onclick="window.open('{{ site.github.repository_url }}/edit/master/{{ page.path }}', '_blank');" class="btn btn--primary">
-  <i class="fab fa-fw fa-github"></i> Edit
-</button>
+{% capture edit_uri %}{{ site.github.repository_url }}/edit/master/{{ page.path }}{% endcapture %}
+{% capture issue_uri %}{{ site.github.repository_url }}/issues/new?title=Issue%20with%20{{ page.title | uri_escape }}&body={{ page.path | uri_escape }} {% endcapture %}
+<button onclick="window.open('{{ edit_uri }}', '_blank');" class="btn btn--primary btn--small" title="Edit this file on Github"><i class="fab fa-fw fa-github"></i> Edit</button>
+<button onclick="window.open('{{ issue_uri }}', '_blank');" class="btn btn--primary btn--small" title="Report an issue with this page on Github"><i class="fas fa-fw fa-bug"></i> Report issue</button>

--- a/_includes/footer/custom.html
+++ b/_includes/footer/custom.html
@@ -1,0 +1,3 @@
+<button onclick="window.open('{{ site.github.repository_url }}/edit/master/{{ page.path }}', '_blank');" class="btn btn--primary">
+  <i class="fab fa-fw fa-github"></i> Edit
+</button>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -39,3 +39,7 @@ a.missing:visited {
     padding: 1em;
   }
 }
+
+.page__footer-git {
+  font-size: $type-size-7;
+}


### PR DESCRIPTION
As we host this website from a public repository, why not add the git information to the website?

if we merge this PR, we add an _Edit_ button to edit the current page in the github repository, and we add the revision info and date in the footer (see https://122-267395254-gh.circle-artifacts.com/0/SORSE20/index.html for instance).

![image](https://user-images.githubusercontent.com/9960249/84763050-eb5a3180-afcb-11ea-953a-cccd96fb4402.png)

what do you think about it?