### PR TITLE
Removed teams from programme navigation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -62,10 +62,6 @@ programme:
     children:
       - title: "Call for Contributions"
         url: "/programme/call-for-contributions/"
-      - title: "Topic Bazaar"
-        url: "/programme/call-for-contributions/#topic-bazaar"
-  - title: "Teams"
-    children:
       - title: Awards
         url: "/programme/awards/"
       - title: Panels and Discussions


### PR DESCRIPTION
All programme items are now in the same section. Closes #67 

<img width="209" alt="Screenshot 2020-06-17 at 07 43 28" src="https://user-images.githubusercontent.com/8916421/84864281-54928100-b06e-11ea-9f95-7bc619c84940.png">
