### PR TITLE
Revert "Add git metadata to website"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ _site
 .sass-cache
 .jekyll-metadata
 Gemfile.lock
-.git-metadata

--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,4 @@ group :jekyll_plugins do
   gem "jemoji"
   gem "jekyll-include-cache"
   gem "jekyll-algolia"
-  gem 'jekyll-git_metadata'
 end

--- a/_config.yml
+++ b/_config.yml
@@ -56,9 +56,6 @@ plugins:
   - jemoji
   - jekyll-include-cache
 
-github:
-  repository_url: https://github.com/RSE-leaders/SORSE20
-
 author:
   name   : "SORSE"
   avatar : "/assets/images/bio-photo.jpg"

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -22,6 +22,4 @@
   {% endfor %}
 </div>
 
-<div class="page__footer-git">Build at revision <a href="https://github.com/RSE-leaders/SORSE20/tree/{{ site.git.last_commit.long_sha }}" data-proofer-ignore><code>{{ site.git.last_commit.short_sha }}</code></a> on {{ site.git.last_commit.commit_date | date_to_string: "ordinal", "US" }}.</div>
-
 <div class="page__footer-copyright">&copy; {{ site.time | date: '%Y' }} {{ site.name | default: site.title }}. {{ site.data.ui-text[site.locale].powered_by | default: "Powered by" }} <a href="https://jekyllrb.com" rel="nofollow">Jekyll</a> &amp; <a href="https://mademistakes.com/work/minimal-mistakes-jekyll-theme/" rel="nofollow">Minimal Mistakes</a>.</div>

--- a/_includes/footer/custom.html
+++ b/_includes/footer/custom.html
@@ -1,4 +1,0 @@
-{% capture edit_uri %}{{ site.github.repository_url }}/edit/master/{{ page.path }}{% endcapture %}
-{% capture issue_uri %}{{ site.github.repository_url }}/issues/new?title=Issue%20with%20{{ page.title | uri_escape }}&body={{ page.path | uri_escape }} {% endcapture %}
-<button onclick="window.open('{{ edit_uri }}', '_blank');" class="btn btn--primary btn--small" title="Edit this file on Github"><i class="fab fa-fw fa-github"></i> Edit</button>
-<button onclick="window.open('{{ issue_uri }}', '_blank');" class="btn btn--primary btn--small" title="Report an issue with this page on Github"><i class="fas fa-fw fa-bug"></i> Report issue</button>

--- a/_includes/footer/custom.html
+++ b/_includes/footer/custom.html
@@ -1,0 +1,4 @@
+{% capture edit_uri %}https://github.com/{{ site.repository }}/edit/master/{{ page.path }}{% endcapture %}
+{% capture issue_uri %}https://github.com/{{ site.repository }}/issues/new?title=Issue%20with%20{{ page.title | uri_escape }}&body={{ page.path | uri_escape }} {% endcapture %}
+<button onclick="window.open('{{ edit_uri }}', '_blank');" class="btn btn--primary btn--small" title="Edit this file on Github"><i class="fab fa-fw fa-github"></i> Edit</button>
+<button onclick="window.open('{{ issue_uri }}', '_blank');" class="btn btn--primary btn--small" title="Report an issue with this page on Github"><i class="fas fa-fw fa-bug"></i> Report issue</button>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -39,7 +39,3 @@ a.missing:visited {
     padding: 1em;
   }
 }
-
-.page__footer-git {
-  font-size: $type-size-7;
-}


### PR DESCRIPTION
Reverts RSE-leaders/SORSE20#77

apparently Github Pages has a problem with `jekyll-git_metadata`. I'll nevertheless add the buttons