### PR TITLE
Add all abouts to navigation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -17,6 +17,8 @@ news:
         url: "/faq/about/what-is-sorse"
       - title: "Format of SORSE"
         url: /faq/about/format-of-sorse
+      - title: Tools
+        url: /faq/howto/tools
       - title: "Registration and Fees"
         url: /faq/about/costs
       - title: Attending an event

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -29,11 +29,6 @@ news:
     url: /news/
   - title: FAQ
     url: /faq/
-    children:
-      - title: About
-        url: /faq/#about
-      - title: How it works
-        url: /faq/#how-it-work
 
 contact:
   - *sorse20

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -80,6 +80,8 @@ programme:
         url: "/programme/bazaar/"
       - title: Workshops
         url: "/programme/workshops/"
+      - title: Blog Posts
+        url: /faq/howto/contribute-blog-posts
 
 bazaar:
   - title: Other topics

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -20,6 +20,7 @@ news:
       - title: "Registration and Fees"
         url: /faq/about/costs
   - title: "Get involved!"
+    url: /faq/howto/get-involved
     children:
       - title: "Call for Contributions"
         url: "/programme/call-for-contributions/"

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -16,7 +16,9 @@ news:
       - title: "What is SORSE?"
         url: "/faq/about/what-is-sorse"
       - title: "Format of SORSE"
-        url: "/faq/about/format-of-sorse"
+        url: /faq/about/format-of-sorse
+      - title: "Registration and Fees"
+        url: /faq/about/costs
   - title: "Get involved!"
     children:
       - title: "Call for Contributions"

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -15,6 +15,8 @@ news:
     children:
       - title: "What is SORSE?"
         url: "/faq/about/what-is-sorse"
+      - title: "Format of SORSE"
+        url: "/faq/about/format-of-sorse"
   - title: "Get involved!"
     children:
       - title: "Call for Contributions"

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -19,6 +19,8 @@ news:
         url: /faq/about/format-of-sorse
       - title: "Registration and Fees"
         url: /faq/about/costs
+      - title: Attending an event
+        url: /faq/howto/attendance
   - title: "Get involved!"
     url: /faq/howto/get-involved
     children:


### PR DESCRIPTION
This PR updates the navigation as suggested by @ClaireWyatt.

Please have a look at https://166-267395254-gh.circle-artifacts.com/0/SORSE20/index.html and https://166-267395254-gh.circle-artifacts.com/0/SORSE20/programme/call-for-contributions/index.html to see the changes.

The main menu now looks like
<img src="https://user-images.githubusercontent.com/9960249/85184761-55572d00-b291-11ea-8e49-f05e1b6e1b45.png" width="300px" />

and the programme navigation like this (I added the blog posts here).
<img src="https://user-images.githubusercontent.com/9960249/85184832-8c2d4300-b291-11ea-9ca5-bcdd9f23e7c1.png" width="300px" />

closes #95, closes #96, closes #99, closes #100, closes #105
link #104 