### PR TITLE
Add Code of Conduct to the website

### DIFF
--- a/_data/committee/committees.yml
+++ b/_data/committee/committees.yml
@@ -11,3 +11,6 @@ website:
 sponsoring:
   name: Sponsorship Committee
   internal: /contact/committees/#sponsoring
+coc:
+  name: Code of Conduct
+  internal: /code-of-conduct/

--- a/_data/committee/members.yml
+++ b/_data/committee/members.yml
@@ -130,6 +130,7 @@
     - orga
     - programme
     - sponsoring
+    - coc
 - name: Martin Callaghan
   avatar: /assets/images/Martin_Callaghan.jpg
   hidden: true
@@ -259,6 +260,7 @@
   teams:
     - ukRSE
     - programme
+    - coc
     - talk
     - panel
 - name: Louise Brown

--- a/_data/committee/members.yml
+++ b/_data/committee/members.yml
@@ -157,6 +157,7 @@
   email: k.pringle@leeds.ac.uk
   teams:
     - ukRSE
+    - coc
 - name: Chris Cave-Ayland
   affiliation: Imperial College
   location: London, UK

--- a/_data/committee/members.yml
+++ b/_data/committee/members.yml
@@ -165,6 +165,7 @@
   email: c.cave-ayland@imperial.ac.uk
   teams:
     - ukRSE
+    - coc
     - talk
     - workshop
 - name: Alison Clarke

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -30,6 +30,8 @@ news:
         url: /faq/#about
       - title: How it works
         url: /faq/#how-it-work
+  - title: Code of Conduct
+    url: /code-of-conduct/
 
 contact:
   - *sorse20
@@ -81,6 +83,14 @@ programme:
       - title: Workshops
         url: "/programme/workshops/"
 
+coc:
+  - *sorse20
+  - title: Code of Conduct
+    url: /code-of-conduct/
+    children:
+      - title: Report harassment
+        url: /code-of-conduct/report
+
 bazaar:
   - title: Other topics
     url: "/programme/bazaar/#topics"
@@ -104,3 +114,5 @@ footer:
     url: "/faq/"
   - title: Archive
     url: "/archive/"
+  - title: Code of Conduct
+    url: /code-of-conduct/

--- a/_pages/coc/code-of-conduct.md
+++ b/_pages/coc/code-of-conduct.md
@@ -7,8 +7,6 @@ toc: true
 toc_sticky: true
 ---
 
-# Code of Conduct
-
 We value the participation of each stakeholder and want all participants to have an enjoyable and fulfilling experience. Accordingly, all participants are expected to show respect and courtesy to other participants throughout the events and through all communication channels, including but not limited to the zoom room, zoom webinar, youtube channel, discord platform and the slack channel.  
 
 To make clear what is expected, all participants, speakers, exhibitors, organisers and volunteers involved in SORSE are required to conform to the following Code of Conduct. Organisers will enforce this code.

--- a/_pages/coc/code-of-conduct.md
+++ b/_pages/coc/code-of-conduct.md
@@ -7,6 +7,8 @@ toc: true
 toc_sticky: true
 ---
 
+# Code of Conduct
+
 We value the participation of each stakeholder and want all participants to have an enjoyable and fulfilling experience. Accordingly, all participants are expected to show respect and courtesy to other participants throughout the events and through all communication channels, including but not limited to the zoom room, zoom webinar, youtube channel, discord platform and the slack channel.  
 
 To make clear what is expected, all participants, speakers, exhibitors, organisers and volunteers involved in SORSE are required to conform to the following Code of Conduct. Organisers will enforce this code.

--- a/_pages/coc/code-of-conduct.md
+++ b/_pages/coc/code-of-conduct.md
@@ -1,5 +1,5 @@
 ---
-tite: Code of Conduct
+title: Code of Conduct
 permalink: /code-of-conduct/
 sidebar:
   nav: coc

--- a/_pages/coc/code-of-conduct.md
+++ b/_pages/coc/code-of-conduct.md
@@ -1,0 +1,51 @@
+---
+tite: Code of Conduct
+permalink: /code-of-conduct/
+sidebar:
+  nav: coc
+toc: true
+toc_sticky: true
+---
+
+We value the participation of each stakeholder and want all participants to have an enjoyable and fulfilling experience. Accordingly, all participants are expected to show respect and courtesy to other participants throughout the events and through all communication channels, including but not limited to the zoom room, zoom webinar, youtube channel, discord platform and the slack channel.  
+
+To make clear what is expected, all participants, speakers, exhibitors, organisers and volunteers involved in SORSE are required to conform to the following Code of Conduct. Organisers will enforce this code.
+
+## Summary
+
+SORSE organisers are dedicated to providing a harassment-free experience for everyone. We do not tolerate harassment of participants in any form.  All communication should be appropriate for a professional audience including people of many different backgrounds.
+
+Be kind to others. Do not insult or put down other attendees.
+
+Behave professionally. Remember that harassment and exclusionary jokes are not appropriate. Do not send any unprofessional messages to other participants, including but not limited to private messages in Slack, Zoom and Discord.
+
+Participants violating these rules may be asked to leave the event at the sole discretion of the SORSE organisers.
+
+Thank you for helping make this a welcoming, friendly event for all.
+
+
+## Clarifications
+
+Harassment includes offensive communication related to gender, sexual orientation, disability, physical appearance, body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.
+
+Participants asked to stop any harassing behaviour are expected to comply immediately.
+
+Be careful in the words that you choose. Remember that words can be offensive to those around you. Offensive jokes are not acceptable at the SORSE events. Excessive swearing is not appropriate.
+
+If a participant engages in behaviour that violates this code of conduct, the SORSE organisers may take any action they deem appropriate, including warning the offender or expulsion from the event and it may affect the offenders' ability to join future events.
+
+## Contact Information
+
+If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact any member of the Code of Conduct team:
+
+{% include team-members.html team="coc" %}
+
+The Code of Conduct team is happy to assist those experiencing harassment to feel safe for the duration of the event. We value your participation.
+
+## Procedure for Reporting Harassment
+
+You can find the Attendee Procedure For Reporting Harassment [here](report).
+
+## Acknowledgement
+
+This Code of Conduct was adapted from the example policy for the CW20 and also from the Geek Feminism wiki, created by the Ada Initiative and other volunteers, which is under a Creative Commons Zero license.

--- a/_pages/coc/report.md
+++ b/_pages/coc/report.md
@@ -1,0 +1,32 @@
+---
+title: Attendee Procedure For Reporting Harassment
+permalink: /code-of-conduct/report
+sidebar:
+  nav: coc
+---
+
+Please contact either member of the Code of Conduct (CoC) team:
+
+{% include team-members.html team="coc" %}
+
+The CoC team is prepared to handle the incident. Both of our team members are informed of the Code of Conduct policy and guide for handling harassment at the workshop. There will be a mandatory CoC Committee meeting just prior to the series launch when this will be reiterated as well.
+
+Report the harassment incident via private message in Slack or as an email to a member of the CoC team. All reports are confidential.
+
+When reporting the event to a CoC team member, try to gather as much information as available, but do not interview people about the incident. The CoC team member will assist you in writing the report/collecting information.
+
+The important information we need consists of:
+
+* Identifying information (name) of the participant doing the harassing
+* The behaviour that was in violation
+* The approximate time of the behaviour (if different than the time the report was made)
+* The circumstances surrounding the incident
+* Other people involved in the incident
+
+The CoC team is well informed on how to deal with the incident and how to further proceed with the situation.
+
+Even though this is an online workshop if at any time you feel that your personal safety is in jeopardy then contact your local Police / law enforcement service.
+
+## Acknowledgement
+
+This procedure has been adopted from the Ada Initiative's guide titled "workshop anti-harassment/Responding to Reports”.


### PR DESCRIPTION
This PR adds the code of conduct and associates @ClaireWyatt and @MarionBWeinzierl with the Code of Conduct team.

Please review the following pages:

* [the front page](https://175-267395254-gh.circle-artifacts.com/0/SORSE20/index.html), where the CoC appears in the sidebar and the footer
* the [CoC page](https://175-267395254-gh.circle-artifacts.com/0/SORSE20/code-of-conduct/index.html)
* the [report page](https://175-267395254-gh.circle-artifacts.com/0/SORSE20/code-of-conduct/report.html)

closes #93, closes #103