### PR TITLE
Add FAQ about Who is organizing SORSE

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -100,6 +100,8 @@ footer:
     url: "/programme/"
   - title: Contact
     url: "/contact/"
+  - title: About
+    url: "/faq#about"
   - title: FAQ
     url: "/faq/"
   - title: Archive

--- a/_faq/about/04-organizers.md
+++ b/_faq/about/04-organizers.md
@@ -1,0 +1,29 @@
+---
+title: Who is organizing SORSE20
+permalink: /faq/about/organizers
+classes: wide
+tags:
+  - About
+---
+SORSE20 is organized by [volunteers]({% include fix-link.html link="/contact/" %})
+from the international Research Software Engineers community. This work is made
+possible by various [national RSE chapters]({% include fix-link.html link="/contact/chapters" %}),
+namely
+
+<ul>
+  {% for item in site.data.committee.national_chapters %}
+  {% assign org = item[1] %}
+  <li>
+    {{ org.long_name }}
+    {% if org.website %}
+    <a href="{{ org.website }}"><span><i class="elastic-fai fas fa-globe"></i></span></a>
+    {% endif %}
+    {% if org.email %}
+    <a href="mailto:{{ org.email }}" title="{{ org.email }}"><span><i class="elastic-fai fas fa-envelope"></i></span></a>
+    {% endif %}
+  </li>
+  {% endfor %}
+</ul>
+
+Please see the [contact page]({% include fix-link.html link="/contact/" %}) for
+more information.

--- a/_faq/about/04-organizers.md
+++ b/_faq/about/04-organizers.md
@@ -27,3 +27,6 @@ namely
 
 Please see the [contact page]({% include fix-link.html link="/contact/" %}) for
 more information.
+
+## Further links
+{% include team-button.html team="orga" %}

--- a/_includes/card.html
+++ b/_includes/card.html
@@ -46,24 +46,7 @@
       {% endif %}
       <br>
       {% for team in info.teams %}
-        {% if site.data.committee.national_chapters[team] %}
-            {% assign team_info = site.data.committee.national_chapters[team] %}
-            {% assign btn_class = "btn--danger" %}
-        {% elsif site.data.committee.committees[team] %}
-            {% assign team_info = site.data.committee.committees[team] %}
-            {% assign btn_class = "btn--info" %}
-        {% else %}
-          {% assign team_info = site.data.committee.programme_teams[team] %}
-          {% assign btn_class = "btn--primary" %}
-        {% endif %}
-        <a class="btn btn--small {{ btn_class }}"
-         {% if team_info.internal %}
-         href="{{ site.baseurl }}{{ team_info.internal }}"
-         {% elsif team_info.website %}
-         href="{{ team_info.website }}"
-         {% else %}
-         href="#"
-         {% endif %}>{{ team_info.name }}</a>
+        {% include team-button.html teams=team classes="btn--small" %}
       {% endfor %}
     </p>
   </div>

--- a/_includes/team-button.html
+++ b/_includes/team-button.html
@@ -1,0 +1,19 @@
+{% assign team = include.team %}
+{% if site.data.committee.national_chapters[team] %}
+    {% assign team_info = site.data.committee.national_chapters[team] %}
+    {% assign btn_class = "btn--danger" %}
+{% elsif site.data.committee.committees[team] %}
+    {% assign team_info = site.data.committee.committees[team] %}
+    {% assign btn_class = "btn--info" %}
+{% else %}
+  {% assign team_info = site.data.committee.programme_teams[team] %}
+  {% assign btn_class = "btn--primary" %}
+{% endif %}
+{% if team_info.internal %}
+  {% assign target = site.baseurl | append: team_info.internal }} %}
+{% elsif team_info.website %}
+  {% assign target = team_info.website %}
+{% else %}
+  {% assign target = "#" %}
+{% endif %}
+<a  href="{{ target }}" class="btn {{ include.classes }} {{ btn_class }}">{{ team_info.name }}</a>


### PR DESCRIPTION
As proposed in https://github.com/RSE-leaders/SORSE20/issues/91#issuecomment-646628655, this PR adds an FAQ about who is organizing SORSE (https://179-267395254-gh.circle-artifacts.com/0/SORSE20/faq/about/organizers.html) and it's adding the About section to the Footer

![image](https://user-images.githubusercontent.com/9960249/85185548-a6b4eb80-b294-11ea-8b1a-0e839c719141.png)

As soon as we have information about sponsors, we should add them here as well.

closes #91