### PR TITLE
allow multiple authors per topic summary

### DIFF
--- a/_includes/topic-summary.html
+++ b/_includes/topic-summary.html
@@ -1,14 +1,5 @@
 {% assign info = include.info %}
 
-{% assign author = info.author | default: info.authors[0] | default: site.author %}
-{% assign author = site.data.authors[author] | default: author %}
-
-{% for link in author.links %}
-    {% if link.label == "Email" %}
-        {% assign email = link %}
-    {% endif %}
-{% endfor %}
-
 {% assign teams = site.data.committee.programme_teams %}
 
 {% if info.type %}<span class="content-line"><b>Type:</b>
@@ -28,9 +19,38 @@
   {% endif %}
 </span>
 
-{% if email %}
-<p class="card-line">
-  <b>Contact:</b> {{ author.name }}
-  <a href="{{ email.url }}" title='{{ email.url | remove: "mailto:" }}'><span>{{ email.url | remove: "mailto:" }}</span></a>
-</p>
+{% if info.authors %}
+  <p class="card-line">
+    <b>Contact:</b>
+    {% for author in info.authors %}
+      {{ author.name }}
+      {% assign email = 0 %}
+      {% for link in author.links %}
+          {% if link.label == "Email" %}
+              {% assign email = link %}
+          {% endif %}
+      {% endfor %}
+      {% unless email == 0 %}
+        <a href="{{ email.url }}" title='{{ email.url | remove: "mailto:" }}'><span>{{ email.url | remove: "mailto:" }}</span></a>
+      {% endunless %}
+      {% unless forloop.last %}, {% endunless %}
+
+    {% endfor %}
+
+  </p>
+{% else %}
+  {% assign author = info.author | default: info.authors[0] | default: site.author %}
+  {% assign author = site.data.authors[author] | default: author %}
+
+  {% for link in author.links %}
+      {% if link.label == "Email" %}
+          {% assign email = link %}
+      {% endif %}
+  {% endfor %}
+  {% if email %}
+    <p class="card-line">
+      <b>Contact:</b> {{ author.name }}
+      <a href="{{ email.url }}" title='{{ email.url | remove: "mailto:" }}'><span>{{ email.url | remove: "mailto:" }}</span></a>
+    </p>
+  {% endif %}
 {% endif %}

--- a/_includes/topic-summary.html
+++ b/_includes/topic-summary.html
@@ -23,6 +23,7 @@
   <p class="card-line">
     <b>Contact:</b>
     {% for author in info.authors %}
+      {% assign author = site.data.authors[author] | default: author %}
       {{ author.name }}
       {% assign email = 0 %}
       {% for link in author.links %}


### PR DESCRIPTION
This PR makes a change to the topic summary to display multiple authors (if they are specified).

To use multiple authors, you need to use *authors* instead of *author* and give a list in the header. For instance

instead of 
```yaml
author:
  links:
  - icon: fas fa-fw fa-envelope-square
    label: Email
    url: mailto:rse@fthiery.de
  name: Florian Thiery / Research Squirrel Engineers
```
you need
```yaml
authors:
  - links:
    - icon: fas fa-fw fa-envelope-square
      label: Email
      url: mailto:rse@fthiery.de
    name: Florian Thiery / Research Squirrel Engineers
  - links:
    - icon: fas fa-fw fa-envelope-square
      label: Email
      url: mailto:rse@fthiery.de
    name: second author
```

@florianthiery does this work for your purposes?