### PR TITLE
Topic emails

### DIFF
--- a/_bazaar/developing-distributing-and-testing-research-software-with-anaconda.md
+++ b/_bazaar/developing-distributing-and-testing-research-software-with-anaconda.md
@@ -1,9 +1,6 @@
 ---
 author:
-  links:
-  - icon: fas fa-fw fa-envelope-square
-    label: Email
-    url: mailto:philipp.sommer@hzg.de
+  email: philipp.sommer@hzg.de
   name: Philipp S. Sommer
 contributors: This workshop is supposed to be community-driven and I have no clue
   about whether it is useful or not! Therefore, please let me know what you think

--- a/_bazaar/examples-and-discussion-how-to-do-good-tutorials-for-research-software.md
+++ b/_bazaar/examples-and-discussion-how-to-do-good-tutorials-for-research-software.md
@@ -1,9 +1,6 @@
 ---
 author:
-  links:
-  - icon: fas fa-fw fa-envelope-square
-    label: Email
-    url: mailto:rene.fritze@wwu.de
+  email: rene.fritze@wwu.de
   name: "Ren\xE9 Fritze"
 contributors: "We are looking for 5 minutes presentations of developers presenting\
   \ \u201Ctheir\u201D tutorials. This needs nearly no preparation, just clicking through\

--- a/_bazaar/legal-issues-in-research-software-development.md
+++ b/_bazaar/legal-issues-in-research-software-development.md
@@ -1,9 +1,6 @@
 ---
 author:
-  links:
-  - icon: fas fa-fw fa-envelope-square
-    label: Email
-    url: mailto:christian.busse@dkfz-heidelberg.de
+  email: christian.busse@dkfz-heidelberg.de
   name: Christian Busse
 looking: true
 title: Legal Issues in Research Software Development

--- a/_bazaar/medical-healthcare-rse.md
+++ b/_bazaar/medical-healthcare-rse.md
@@ -1,9 +1,6 @@
 ---
 author:
-  links:
-  - icon: fas fa-fw fa-envelope-square
-    label: Email
-    url: mailto:markus.suhr@med.uni-goettingen.de
+  email: markus.suhr@med.uni-goettingen.de
   name: Markus Suhr
 contributors: Contact me if you want to join in and share ideas for the organisation!
 looking: true

--- a/_bazaar/research-software-discovery.md
+++ b/_bazaar/research-software-discovery.md
@@ -1,9 +1,6 @@
 ---
 author:
-  links:
-  - icon: fas fa-fw fa-envelope-square
-    label: Email
-    url: mailto:Alexander.Struck@hu-berlin.de
+  email: Alexander.Struck@hu-berlin.de
   name: Alexander Struck
 looking: true
 title: Research Software Discovery

--- a/_bazaar/rse-communities-national-regional-and-local.md
+++ b/_bazaar/rse-communities-national-regional-and-local.md
@@ -1,9 +1,6 @@
 ---
 author:
-  links:
-  - icon: fas fa-fw fa-envelope-square
-    label: Email
-    url: mailto:jeremy.cohen@imperial.ac.uk
+  email: jeremy.cohen@imperial.ac.uk
   name: Jeremy Cohen
 looking: true
 title: 'RSE Communities: National, Regional and Local'

--- a/_bazaar/rse-education.md
+++ b/_bazaar/rse-education.md
@@ -1,9 +1,6 @@
 ---
 author:
-  links:
-  - icon: fas fa-fw fa-envelope-square
-    label: Email
-    url: mailto:a.l.lamprecht@uu.nl
+  email: a.l.lamprecht@uu.nl
   name: Anna-Lena Lamprecht
 looking: true
 title: RSE Education
@@ -12,5 +9,5 @@ type: workshop
 
 We’d like to run a workshop about teaching RSE and incorporating RSE into teaching. Possible topics:
  * What to teach?
- * Where does it fit in? 
+ * Where does it fit in?
  * Who visits these courses?

--- a/_bazaar/rse-for-human-centered-research-workflow-support-systems.md
+++ b/_bazaar/rse-for-human-centered-research-workflow-support-systems.md
@@ -1,9 +1,6 @@
 ---
 author:
-  links:
-  - icon: fas fa-fw fa-envelope-square
-    label: Email
-    url: mailto:johannes.sautter@iao.fraunhofer.de
+  email: johannes.sautter@iao.fraunhofer.de
   name: Johannes Sautter
 contributors: Contact me for some feedback and if you are interested to join and share
   ideas for the organisation!

--- a/_bazaar/rse-research-challenges.md
+++ b/_bazaar/rse-research-challenges.md
@@ -1,9 +1,6 @@
 ---
 author:
-  links:
-  - icon: fas fa-fw fa-envelope-square
-    label: Email
-    url: mailto:a.l.lamprecht@uu.nl
+  email: a.l.lamprecht@uu.nl
   name: Anna-Lena Lamprecht
 looking: true
 title: RSE Research Challenges

--- a/_bazaar/rses-and-their-position.md
+++ b/_bazaar/rses-and-their-position.md
@@ -1,9 +1,6 @@
 ---
 author:
-  links:
-  - icon: fas fa-fw fa-envelope-square
-    label: Email
-    url: mailto:Bernadette.Fritzsch@awi.de
+  email: Bernadette.Fritzsch@awi.de
   name: Bernadette Fritzsch
 contributors: If you have experiences with pay scale classifications of people working
   as RSE and can share with us, it can help the community a lot to establish RSEs

--- a/_bazaar/women-and-diversity-in-research-software-development.md
+++ b/_bazaar/women-and-diversity-in-research-software-development.md
@@ -1,9 +1,6 @@
 ---
 author:
-  links:
-  - icon: fas fa-fw fa-envelope-square
-    label: Email
-    url: mailto:Bernadette.Fritzsch@awi.de
+  email: Bernadette.Fritzsch@awi.de
   name: Bernadette Fritzsch
 contributors: Contact me if you are interested to join and have ideas for the organisation
   of the workshop!
@@ -12,7 +9,7 @@ title: Women and Diversity in Research Software Development
 type: workshop
 ...
 
-After holding a workshop on women in the development of research software last year, we want to continue with the topic of women (and more generally) diversity. Possible topics for a workshop would be: 
- * Compatibility of career and family planning 
- * Information about mentoring programs 
+After holding a workshop on women in the development of research software last year, we want to continue with the topic of women (and more generally) diversity. Possible topics for a workshop would be:
+ * Compatibility of career and family planning
+ * Information about mentoring programs
  * Creating of an atmosphere in meetings etc., in which diversity in the working groups is promoted

--- a/_includes/topic-summary.html
+++ b/_includes/topic-summary.html
@@ -25,15 +25,17 @@
     {% for author in info.authors %}
       {% assign author = site.data.authors[author] | default: author %}
       {{ author.name }}
-      {% assign email = 0 %}
-      {% for link in author.links %}
-          {% if link.label == "Email" %}
-              {% assign email = link %}
-          {% endif %}
-      {% endfor %}
-      {% unless email == 0 %}
-        <a href="{{ email.url }}" title='{{ email.url | remove: "mailto:" }}'><span>{{ email.url | remove: "mailto:" }}</span></a>
+      {% assign email = author.email %}
+      {% unless email %}
+        {% for link in author.links %}
+            {% if link.label == "Email" %}
+                {% assign email = link.url %}
+            {% endif %}
+        {% endfor %}
       {% endunless %}
+      {% if email %}
+        <a href="{{ email }}" title='{{ email | remove: "mailto:" }}'><span>{{ email | remove: "mailto:" }}</span></a>
+      {% endif %}
       {% unless forloop.last %}, {% endunless %}
 
     {% endfor %}
@@ -43,15 +45,18 @@
   {% assign author = info.author | default: info.authors[0] | default: site.author %}
   {% assign author = site.data.authors[author] | default: author %}
 
-  {% for link in author.links %}
-      {% if link.label == "Email" %}
-          {% assign email = link %}
-      {% endif %}
-  {% endfor %}
+  {% assign email = author.email %}
+  {% unless email %}
+    {% for link in author.links %}
+        {% if link.label == "Email" %}
+            {% assign email = link.url %}
+        {% endif %}
+    {% endfor %}
+  {% endunless %}
   {% if email %}
     <p class="card-line">
       <b>Contact:</b> {{ author.name }}
-      <a href="{{ email.url }}" title='{{ email.url | remove: "mailto:" }}'><span>{{ email.url | remove: "mailto:" }}</span></a>
+      <a href="{{ email }}" title='{{ email | remove: "mailto:" }}'><span>{{ email | remove: "mailto:" }}</span></a>
     </p>
   {% endif %}
 {% endif %}


### PR DESCRIPTION
this PR is a follow-up on #119 based on https://github.com/RSE-leaders/SORSE20/pull/120#issuecomment-647466407

the topic summary now also uses the email attribute, so I shortened the author information. This makes it much more easy.

@florianthiery: I did not edit your topic now to avoid merge conflicts, but you can do this in #120