### PR TITLE
Fixed link to international committee members

### DIFF
--- a/_faq/about/01-what-is-sorse.md
+++ b/_faq/about/01-what-is-sorse.md
@@ -5,7 +5,7 @@ tags:
   - About
 ---
 
-With the cancellation of several international Research Software Engineering (RSE) community events as a result of the COVID-19 pandemic, RSEs worldwide are facing a lack of opportunities to engage with their wider community. To address this challenge, SORSE has been launched by an [international committee](contact/#international-committee-members) to provide an opportunity for RSEs to develop and grow their skills, build new collaborations and engage with RSEs worldwide. Until we can meet again in person, SORSE (pronounced ‘Source’), will bridge the gap and be the source of interesting and engaging events.
+With the cancellation of several international Research Software Engineering (RSE) community events as a result of the COVID-19 pandemic, RSEs worldwide are facing a lack of opportunities to engage with their wider community. To address this challenge, SORSE has been launched by an [international committee]({% include fix-link.html link="/contact/chapters" %}) to provide an opportunity for RSEs to develop and grow their skills, build new collaborations and engage with RSEs worldwide. Until we can meet again in person, SORSE (pronounced ‘Source’), will bridge the gap and be the source of interesting and engaging events.
 
 This is an open call to all RSEs and anyone involved with research software, worldwide, to propose talks, workshops and other types of online events.
 


### PR DESCRIPTION
<!---
Thanks for your contribution!

Please indicate whether this PR is ready to be reviewed in your description. 
Otherwise, in case this PR is still work in progress, use the drop down menu 
next to "Create pull request" and select "Create draft pull request"
--->
The FAQ page linking to international committee members now renders a correct link to contact details.
As the section on international committee members does not exist anymore, the link now points to the various national RSE chapters at https://rse-leaders.github.io/SORSE20/contact/chapters/.

Closes #154.